### PR TITLE
Fixed a small deprecation warning.

### DIFF
--- a/lib/active_record/patches.rb
+++ b/lib/active_record/patches.rb
@@ -22,7 +22,7 @@ module ActiveRecord
             fiber.resume(false)
           end
           @queue << fiber
-          returning Fiber.yield do
+          Fiber.yield.tap do
             x.cancel
           end
         end


### PR DESCRIPTION
A tiny patch resolving a deprecation warning for Object#returning. I just replaced it with Object#tap.
